### PR TITLE
Modified Logger

### DIFF
--- a/client/connection_manager.py
+++ b/client/connection_manager.py
@@ -29,7 +29,7 @@ class ConnectionManager(object):
                           requests.exceptions.MissingSchema,
                           )
 
-    def __init__(self, cfg, logging_level=logging.INFO):
+    def __init__(self, cfg, logging_level=logging.ERROR):
         self.cfg = cfg
         self.auth = (self.cfg['user'], self.cfg['pass'])
 


### PR DESCRIPTION
The default level of logger is ERROR. In this way we can see the exceptions of the requests. Modify to INFO  if you want to see all requests or read the log file in the log folder
