### PR TITLE
Client remove the left empty directories when delete or move files

### DIFF
--- a/client/client_daemon.py
+++ b/client/client_daemon.py
@@ -299,7 +299,7 @@ class Daemon(FileSystemEventHandler):
         else:
             return None
 
-    def remove_dir_if_empty(self, dir_path, recursive=True):
+    def _remove_dir_if_empty(self, dir_path, recursive=True):
         """
         Given a directory path, delete it if empty.
         If <recursive> is True, act recursively on the upper dir.
@@ -315,7 +315,7 @@ class Daemon(FileSystemEventHandler):
             os.rmdir(dir_path)
 
             if recursive:
-                self.remove_dir_if_empty(os.path.dirname(dir_path))
+                self._remove_dir_if_empty(os.path.dirname(dir_path))
 
     def _make_copy_on_client(self, src, dst):
         """
@@ -370,7 +370,7 @@ class Daemon(FileSystemEventHandler):
             return False
         else:
             # After removing the file, remove the directory if it is empty.
-            self.remove_dir_if_empty(os.path.dirname(abs_src))
+            self._remove_dir_if_empty(os.path.dirname(abs_src))
 
         self.client_snapshot[dst] = self.client_snapshot[src]
         self.client_snapshot.pop(src)
@@ -395,7 +395,7 @@ class Daemon(FileSystemEventHandler):
                            'Error occurred: {}'.format(abs_path, e))
         else:
             # After deleting the file, remove the directory if it is empty.
-            self.remove_dir_if_empty(os.path.dirname(abs_path))
+            self._remove_dir_if_empty(os.path.dirname(abs_path))
 
         if self.client_snapshot.pop(filepath, 'ERROR') != 'ERROR':
             logger.info('Deleted file on client during SYNC.\nDeleted filepath: {}'.format(abs_path))

--- a/client/client_daemon.py
+++ b/client/client_daemon.py
@@ -80,14 +80,23 @@ def is_directory(method):
     return wrapper
 
 
-def remove_dir_if_empty(dir_path):
+def remove_dir_if_empty(dir_path, sharing_path, recursive=True):
     """
     Given a directory path, delete it if empty.
+    If <recursive> is True, act recursively on the upper dir.
+
     :param dir_path: str
     """
+    if dir_path == sharing_path:
+        # Do not delete the user sharing folder!
+        return
+
     if not os.listdir(dir_path):
         logger.debug('Removing empty directory {}'.format(dir_path))
         os.rmdir(dir_path)
+
+        if recursive:
+            remove_dir_if_empty(os.path.dirname(dir_path), sharing_path)
 
 
 class Daemon(FileSystemEventHandler):
@@ -362,7 +371,7 @@ class Daemon(FileSystemEventHandler):
             return False
         else:
             # After removing the file, remove the directory if it is empty.
-            remove_dir_if_empty(os.path.dirname(abs_src))
+            remove_dir_if_empty(os.path.dirname(abs_src), self.cfg['sharing_path'])
 
         self.client_snapshot[dst] = self.client_snapshot[src]
         self.client_snapshot.pop(src)
@@ -387,7 +396,7 @@ class Daemon(FileSystemEventHandler):
                            'Error occurred: {}'.format(abs_path, e))
         else:
             # After deleting the file, remove the directory if it is empty.
-            remove_dir_if_empty(os.path.dirname(abs_path))
+            remove_dir_if_empty(os.path.dirname(abs_path), self.cfg['sharing_path'])
 
         if self.client_snapshot.pop(filepath, 'ERROR') != 'ERROR':
             logger.info('Deleted file on client during SYNC.\nDeleted filepath: {}'.format(abs_path))

--- a/client/client_daemon.py
+++ b/client/client_daemon.py
@@ -306,7 +306,13 @@ class Daemon(FileSystemEventHandler):
 
         :param dir_path: str
         """
-        if dir_path == self.cfg['sharing_path']:
+        sharing_path = self.cfg['sharing_path']
+        assert sharing_path in dir_path, \
+            'Programming error: I can\'t delete <{}> directory, \
+since it is outside the <{}> sharing path!'.format(dir_path, sharing_path)
+        assert os.path.isdir(dir_path), 'Programming error: <{}> is not a directory!'.format(dir_path)
+
+        if dir_path == sharing_path:
             # Do not delete the user sharing folder!
             return
 

--- a/client/test_client_daemon.py
+++ b/client/test_client_daemon.py
@@ -593,6 +593,29 @@ class TestClientDaemonActions(unittest.TestCase):
 
         self.assertEqual(self.daemon._make_move_on_client(file_to_move, dst_file_exists), True)
 
+    def test_delete_the_last_directory_file_and_check_directory_is_also_removed(self):
+        """
+        Delete (with _make_delete_on_client) an unique file inside a directory
+        and check that also the directory is removed.
+        """
+        # setup
+        filepath = 'folder6/iacopy.txt'
+        create_base_dir_tree([filepath])
+        create_files([filepath])
+
+        # pre-check
+        filename = os.path.basename(filepath)
+        abs_filepath = self.daemon.absolutize_path(filepath)
+        assert os.path.exists(abs_filepath), 'file <{}> does not exist'.format(abs_filepath)
+        abs_dirpath = os.path.dirname(abs_filepath)
+        assert os.path.exists(abs_dirpath) and os.path.isdir(abs_dirpath),\
+            'directory <{}> does not exist'.format(abs_dirpath)
+        assert os.listdir(abs_dirpath) == [filename], 'Wrong initial test conditions'
+
+        # test
+        self.daemon._make_delete_on_client(filepath)
+        self.assertFalse(os.path.exists(abs_dirpath))
+
 
 class TestClientDaemonSync(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Il client ora cancella le directory che rimangono vuote in seguito ad eventi di eliminazione e spostamento di file, facendo sì che la sincronizzazione si comporti come ci si aspetta quando si cancellano, spostano o rinominano alberi di directory, nella maggior parte dei casi.

Prima, quando un client cancellava, spostava o rinominava una directory, il client che si sincronizzava rimaneva con tutto lo "scheletro vuoto" dell'albero originale.
